### PR TITLE
Fix entrypoint

### DIFF
--- a/StaffMod/src/main/resources/fabric.mod.json
+++ b/StaffMod/src/main/resources/fabric.mod.json
@@ -31,7 +31,7 @@
     "avm-staff": [
       {
         "adapter": "kotlin",
-        "value": "opekope2.avm_staff.internal.item_handler.VanillaStaffItemHandlersKt::register"
+        "value": "opekope2.avm_staff.internal.staff_item_handler.VanillaStaffItemHandlersKt::register"
       }
     ]
   },


### PR DESCRIPTION
Fix class path.
Replaced opekope2.avm_staff.internal.item_handler.VanillaStaffItemHandlersKt::register by opekope2.avm_staff.internal.staff_item_handler.VanillaStaffItemHandlersKt::register.