### PR TITLE
Staff Mod 0.13.0-beta

### DIFF
--- a/FabricMod/src/main/kotlin/opekope2/avm_staff/internal/fabric/StaffMod.kt
+++ b/FabricMod/src/main/kotlin/opekope2/avm_staff/internal/fabric/StaffMod.kt
@@ -23,10 +23,12 @@ import net.fabricmc.api.ModInitializer
 import net.fabricmc.fabric.api.event.player.AttackBlockCallback
 import net.fabricmc.fabric.api.event.player.AttackEntityCallback
 import net.fabricmc.fabric.api.item.v1.FabricItemSettings
+import net.fabricmc.fabric.api.particle.v1.FabricParticleTypes
 import net.fabricmc.loader.api.FabricLoader
 import net.minecraft.entity.Entity
 import net.minecraft.entity.player.PlayerEntity
 import net.minecraft.item.Item
+import net.minecraft.particle.DefaultParticleType
 import net.minecraft.registry.Registries
 import net.minecraft.registry.Registry
 import net.minecraft.registry.RegistryKeys
@@ -55,6 +57,18 @@ object StaffMod : ModInitializer, IStaffMod {
         get() = FabricLoader.getInstance().environmentType == EnvType.CLIENT
 
     override val staffsTag: TagKey<Item> = TagKey.of(RegistryKeys.ITEM, Identifier(MOD_ID, "staffs"))
+
+    override val flamethrowerParticleType: DefaultParticleType = Registry.register(
+        Registries.PARTICLE_TYPE,
+        Identifier(MOD_ID, "flame"),
+        FabricParticleTypes.simple()
+    )
+
+    override val soulFlamethrowerParticleType: DefaultParticleType = Registry.register(
+        Registries.PARTICLE_TYPE,
+        Identifier(MOD_ID, "soul_fire_flame"),
+        FabricParticleTypes.simple()
+    )
 
     override fun onInitialize() {
         AttackBlockCallback.EVENT.register(::attackBlock)

--- a/FabricMod/src/main/kotlin/opekope2/avm_staff/internal/fabric/StaffModClient.kt
+++ b/FabricMod/src/main/kotlin/opekope2/avm_staff/internal/fabric/StaffModClient.kt
@@ -25,12 +25,15 @@ import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper
 import net.fabricmc.fabric.api.client.model.loading.v1.ModelLoadingPlugin
 import net.fabricmc.fabric.api.client.model.loading.v1.ModelModifier
+import net.fabricmc.fabric.api.client.particle.v1.ParticleFactoryRegistry
 import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents
 import net.minecraft.client.item.ModelPredicateProviderRegistry
 import net.minecraft.client.render.model.UnbakedModel
 import net.minecraft.client.render.model.json.JsonUnbakedModel
 import net.minecraft.item.ItemGroups
 import net.minecraft.item.Items
+import opekope2.avm_staff.IStaffMod
+import opekope2.avm_staff.api.particle.FlamethrowerParticle
 import opekope2.avm_staff.internal.event_handler.ADD_REMOVE_KEYBINDING
 import opekope2.avm_staff.internal.event_handler.handleKeyBindings
 import opekope2.avm_staff.internal.fabric.item.model.UnbakedFabricStaffItemModel
@@ -53,6 +56,15 @@ object StaffModClient : ClientModInitializer {
         KeyBindingHelper.registerKeyBinding(ADD_REMOVE_KEYBINDING)
 
         ClientTickEvents.END_CLIENT_TICK.register(::handleKeyBindings)
+
+        ParticleFactoryRegistry.getInstance().register(
+            IStaffMod.get().flamethrowerParticleType,
+            FlamethrowerParticle::Factory
+        )
+        ParticleFactoryRegistry.getInstance().register(
+            IStaffMod.get().soulFlamethrowerParticleType,
+            FlamethrowerParticle::Factory
+        )
 
         registerModelPredicateProviders(ModelPredicateProviderRegistry::register)
     }

--- a/FabricMod/src/main/kotlin/opekope2/avm_staff/internal/fabric/item/model/UnbakedFabricStaffItemModel.kt
+++ b/FabricMod/src/main/kotlin/opekope2/avm_staff/internal/fabric/item/model/UnbakedFabricStaffItemModel.kt
@@ -23,8 +23,8 @@ import net.fabricmc.api.Environment
 import net.minecraft.client.render.model.BakedModel
 import net.minecraft.client.render.model.Baker
 import net.minecraft.client.render.model.ModelBakeSettings
+import net.minecraft.client.render.model.ModelLoader
 import net.minecraft.client.render.model.json.JsonUnbakedModel
-import net.minecraft.client.texture.MissingSprite
 import net.minecraft.client.texture.Sprite
 import net.minecraft.client.util.SpriteIdentifier
 import net.minecraft.util.Identifier
@@ -44,7 +44,7 @@ class UnbakedFabricStaffItemModel(private val original: JsonUnbakedModel) : Unba
         return BakedFabricStaffItemModel(
             original.bake(baker, textureGetter, rotationContainer, modelId) ?: return null,
             itemModels,
-            baker.bake(MissingSprite.getMissingSpriteId(), rotationContainer)!!
+            baker.bake(ModelLoader.MISSING_ID, rotationContainer)!!
         )
     }
 }

--- a/ForgeMod/src/main/kotlin/opekope2/avm_staff/internal/forge/StaffMod.kt
+++ b/ForgeMod/src/main/kotlin/opekope2/avm_staff/internal/forge/StaffMod.kt
@@ -19,6 +19,7 @@
 package opekope2.avm_staff.internal.forge
 
 import net.minecraft.item.Item
+import net.minecraft.particle.DefaultParticleType
 import net.minecraft.registry.tag.ItemTags
 import net.minecraft.registry.tag.TagKey
 import net.minecraft.util.Identifier
@@ -42,6 +43,16 @@ object StaffMod : IStaffMod {
 
     private val STAFF_ITEM = ITEMS.register("staff") { ForgeStaffItem(Item.Settings().maxCount(1)) }
 
+    private val PARTICLE_TYPES = DeferredRegister.create(ForgeRegistries.PARTICLE_TYPES, MOD_ID)
+
+    private val FLAMETHROWER_PARTICLE_TYPE = PARTICLE_TYPES.register("flame") {
+        DefaultParticleType(false)
+    }
+
+    private val SOUL_FLAMETHROWER_PARTICLE_TYPE = PARTICLE_TYPES.register("soul_fire_flame") {
+        DefaultParticleType(false)
+    }
+
     init {
         initialize()
         initializeNetworking()
@@ -57,7 +68,14 @@ object StaffMod : IStaffMod {
 
     override val staffsTag: TagKey<Item> = ItemTags.create(Identifier(MOD_ID, "staffs"))
 
+    override val flamethrowerParticleType: DefaultParticleType
+        get() = FLAMETHROWER_PARTICLE_TYPE.get()
+
+    override val soulFlamethrowerParticleType: DefaultParticleType
+        get() = SOUL_FLAMETHROWER_PARTICLE_TYPE.get()
+
     private fun initialize() {
         ITEMS.register(MOD_BUS)
+        PARTICLE_TYPES.register(MOD_BUS)
     }
 }

--- a/ForgeMod/src/main/kotlin/opekope2/avm_staff/internal/forge/StaffModClient.kt
+++ b/ForgeMod/src/main/kotlin/opekope2/avm_staff/internal/forge/StaffModClient.kt
@@ -27,11 +27,14 @@ import net.minecraft.item.Items
 import net.minecraftforge.api.distmarker.Dist
 import net.minecraftforge.api.distmarker.OnlyIn
 import net.minecraftforge.client.event.RegisterKeyMappingsEvent
+import net.minecraftforge.client.event.RegisterParticleProvidersEvent
 import net.minecraftforge.common.MinecraftForge.EVENT_BUS
 import net.minecraftforge.event.BuildCreativeModeTabContentsEvent
 import net.minecraftforge.event.TickEvent
 import net.minecraftforge.eventbus.api.SubscribeEvent
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent
+import opekope2.avm_staff.IStaffMod
+import opekope2.avm_staff.api.particle.FlamethrowerParticle
 import opekope2.avm_staff.internal.event_handler.ADD_REMOVE_KEYBINDING
 import opekope2.avm_staff.internal.event_handler.handleKeyBindings
 import opekope2.avm_staff.internal.platform.forge.getStaffMod
@@ -67,6 +70,12 @@ object StaffModClient {
                 PARENT_AND_SEARCH_TABS
             )
         }
+    }
+
+    @SubscribeEvent
+    fun registerParticleProviders(event: RegisterParticleProvidersEvent) {
+        event.registerSpriteSet(IStaffMod.get().flamethrowerParticleType, FlamethrowerParticle::Factory)
+        event.registerSpriteSet(IStaffMod.get().soulFlamethrowerParticleType, FlamethrowerParticle::Factory)
     }
 
     @SubscribeEvent

--- a/ForgeMod/src/main/kotlin/opekope2/avm_staff/internal/forge/item/model/UnbakedForgeStaffItemModel.kt
+++ b/ForgeMod/src/main/kotlin/opekope2/avm_staff/internal/forge/item/model/UnbakedForgeStaffItemModel.kt
@@ -21,8 +21,8 @@ package opekope2.avm_staff.internal.forge.item.model
 import net.minecraft.client.render.model.BakedModel
 import net.minecraft.client.render.model.Baker
 import net.minecraft.client.render.model.ModelBakeSettings
+import net.minecraft.client.render.model.ModelLoader
 import net.minecraft.client.render.model.json.JsonUnbakedModel
-import net.minecraft.client.texture.MissingSprite
 import net.minecraft.client.texture.Sprite
 import net.minecraft.client.util.SpriteIdentifier
 import net.minecraft.util.Identifier
@@ -44,7 +44,7 @@ class UnbakedForgeStaffItemModel(private val original: JsonUnbakedModel) : Unbak
         return BakedForgeStaffItemModel(
             original.bake(baker, original, textureGetter, rotationContainer, modelId, true) ?: return null,
             itemModels,
-            baker.bake(MissingSprite.getMissingSpriteId(), rotationContainer, textureGetter)!!
+            baker.bake(ModelLoader.MISSING_ID, rotationContainer, textureGetter)!!
         )
     }
 }

--- a/StaffMod/src/main/java/opekope2/avm_staff/mixin/IEntityMixin.java
+++ b/StaffMod/src/main/java/opekope2/avm_staff/mixin/IEntityMixin.java
@@ -1,0 +1,30 @@
+/*
+ * AvM Staff Mod
+ * Copyright (c) 2024 opekope2
+ *
+ * This mod is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This mod is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this mod. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package opekope2.avm_staff.mixin;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.util.math.Vec3d;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(Entity.class)
+public interface IEntityMixin {
+    @Invoker
+    Vec3d invokeGetRotationVector(float pitch, float yaw);
+}

--- a/StaffMod/src/main/java/opekope2/avm_staff/mixin/IParticleMixin.java
+++ b/StaffMod/src/main/java/opekope2/avm_staff/mixin/IParticleMixin.java
@@ -1,0 +1,29 @@
+/*
+ * AvM Staff Mod
+ * Copyright (c) 2024 opekope2
+ *
+ * This mod is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This mod is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this mod. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package opekope2.avm_staff.mixin;
+
+import net.minecraft.client.particle.Particle;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(Particle.class)
+public interface IParticleMixin {
+    @Accessor
+    boolean isStopped();
+}

--- a/StaffMod/src/main/kotlin/opekope2/avm_staff/IStaffMod.kt
+++ b/StaffMod/src/main/kotlin/opekope2/avm_staff/IStaffMod.kt
@@ -18,7 +18,9 @@
 
 package opekope2.avm_staff
 
+import net.minecraft.client.particle.ParticleManager
 import net.minecraft.item.Item
+import net.minecraft.particle.DefaultParticleType
 import net.minecraft.registry.tag.TagKey
 import opekope2.avm_staff.api.item.StaffItem
 import opekope2.avm_staff.internal.platform.getStaffMod
@@ -43,6 +45,24 @@ interface IStaffMod {
      * Gets the [TagKey] containing all the staffs.
      */
     val staffsTag: TagKey<Item>
+
+    /**
+     * Gets the flamethrower's flame particle type.
+     *
+     * Due to how Forge registries work, *always* use this getter instead of storing the result.
+     *
+     * @see ParticleManager.addParticle
+     */
+    val flamethrowerParticleType: DefaultParticleType
+
+    /**
+     * Gets the soul fire flamethrower's flame particle type.
+     *
+     * Due to how Forge registries work, *always* use this getter instead of storing the result.
+     *
+     * @see ParticleManager.addParticle
+     */
+    val soulFlamethrowerParticleType: DefaultParticleType
 
     companion object Holder {
         /**

--- a/StaffMod/src/main/kotlin/opekope2/avm_staff/internal/staff_item_handler/CampfireHandler.kt
+++ b/StaffMod/src/main/kotlin/opekope2/avm_staff/internal/staff_item_handler/CampfireHandler.kt
@@ -1,0 +1,283 @@
+/*
+ * AvM Staff Mod
+ * Copyright (c) 2024 opekope2
+ *
+ * This mod is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This mod is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this mod. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package opekope2.avm_staff.internal.staff_item_handler
+
+import dev.architectury.event.events.common.TickEvent
+import net.fabricmc.api.EnvType
+import net.fabricmc.api.Environment
+import net.minecraft.block.*
+import net.minecraft.client.MinecraftClient
+import net.minecraft.client.option.GraphicsMode
+import net.minecraft.entity.Entity
+import net.minecraft.entity.LivingEntity
+import net.minecraft.entity.player.PlayerEntity
+import net.minecraft.entity.projectile.ProjectileUtil
+import net.minecraft.item.ItemStack
+import net.minecraft.particle.ParticleEffect
+import net.minecraft.server.MinecraftServer
+import net.minecraft.state.property.Properties.LIT
+import net.minecraft.util.Hand
+import net.minecraft.util.TypedActionResult
+import net.minecraft.util.hit.BlockHitResult
+import net.minecraft.util.hit.HitResult
+import net.minecraft.util.math.Box
+import net.minecraft.util.math.MathHelper
+import net.minecraft.util.math.Vec3d
+import net.minecraft.util.math.random.Random
+import net.minecraft.world.RaycastContext
+import net.minecraft.world.World
+import net.minecraft.world.event.GameEvent
+import opekope2.avm_staff.IStaffMod
+import opekope2.avm_staff.api.item.StaffItemHandler
+import opekope2.avm_staff.mixin.IEntityMixin
+import opekope2.avm_staff.util.*
+
+class CampfireHandler(
+    private val particleEffectGetter: (IStaffMod) -> ParticleEffect,
+    private val properties: Properties
+) : StaffItemHandler() {
+    override val maxUseTime: Int
+        get() = 72000
+
+    override fun use(
+        staffStack: ItemStack,
+        world: World,
+        user: PlayerEntity,
+        hand: Hand
+    ): TypedActionResult<ItemStack> {
+        staffStack.getOrCreateNbt().putBoolean(ROCKET_MODE_KEY, user.isSneaking && !user.isOnGround)
+
+        user.setCurrentHand(hand)
+        return TypedActionResult.pass(staffStack)
+    }
+
+    override fun usageTick(staffStack: ItemStack, world: World, user: LivingEntity, remainingUseTicks: Int) {
+        if (!user.canUseStaff) return
+
+        val forward = user.rotationVector
+        val origin = user.approximateStaffTipPosition
+        val target = origin + forward * FLAME_MAX_DISTANCE
+        val relativeRight =
+            (user as IEntityMixin).invokeGetRotationVector(0f, MathHelper.wrapDegrees(user.yaw + 90f)).normalize()
+        val relativeUp = relativeRight.crossProduct(forward).normalize()
+
+        if (world.isClient) {
+            throwFlameParticles(user, target, relativeRight, relativeUp)
+            return
+        }
+
+        for (i in 0 until FLAMETHROWER_CONE_RAYS) {
+            for (j in 0 until FLAMETHROWER_CONE_RAYS) {
+                val xScale = i / (FLAMETHROWER_CONE_RAYS - 1.0) - 0.5
+                val yScale = j / (FLAMETHROWER_CONE_RAYS - 1.0) - 0.5
+
+                val offsetTarget = target +
+                        relativeRight * (xScale * FLAMETHROWER_CONE_END_WIDTH) +
+                        relativeUp * (yScale * FLAMETHROWER_CONE_END_HEIGHT)
+
+                shootFire(
+                    FirePellet(
+                        user,
+                        world,
+                        origin,
+                        (offsetTarget - origin).normalize() * FLAME_SPEED,
+                        FLAME_MAX_AGE
+                    )
+                )
+            }
+        }
+
+        if (staffStack.nbt?.getBoolean(ROCKET_MODE_KEY) == true) {
+            user.addVelocity(forward * -properties.rocketThrust)
+            user.velocityModified = true
+            if (forward.y < 0.0) {
+                // If the user is looking directly upwards, then the Y velocity becomes -0.078 from a much lower value
+                // a game tick before, for some reason. Force looking somewhat down to dampen fall damage, so the player
+                // can't exploit this.
+                user.limitFallDistance()
+            }
+        }
+    }
+
+    @Environment(EnvType.CLIENT)
+    fun throwFlameParticles(user: LivingEntity, target: Vec3d, relativeRight: Vec3d, relativeUp: Vec3d) {
+        val random = Random.create()
+        val particleManager = MinecraftClient.getInstance().particleManager
+
+        val origin = user.approximateStaffTipPosition
+
+        for (i in 0..flameParticleCount) {
+            val xScale = random.nextDouble() - 0.5
+            val yScale = random.nextDouble() - 0.5
+
+            val offsetTarget = target +
+                    relativeRight * (xScale * FLAMETHROWER_CONE_END_WIDTH) +
+                    relativeUp * (yScale * FLAMETHROWER_CONE_END_HEIGHT)
+            val targetDirection = (offsetTarget - origin).normalize()
+            val particleSpeed = targetDirection.normalize() * FLAME_SPEED * (0.9 + Math.random() * 0.2)
+
+            particleManager.addParticle(
+                particleEffectGetter(IStaffMod.get()),
+                origin.x,
+                origin.y,
+                origin.z,
+                particleSpeed.x,
+                particleSpeed.y,
+                particleSpeed.z
+            )!!.maxAge = (0.25 * FLAME_MAX_AGE / (Math.random() * 0.8 + 0.2) - 0.05 * FLAME_MAX_AGE).toInt()
+        }
+    }
+
+    override fun onStoppedUsing(staffStack: ItemStack, world: World, user: LivingEntity, remainingUseTicks: Int) {
+        staffStack.getOrCreateNbt().remove(ROCKET_MODE_KEY)
+    }
+
+    override fun finishUsing(staffStack: ItemStack, world: World, user: LivingEntity): ItemStack {
+        onStoppedUsing(staffStack, world, user, 0)
+        return staffStack
+    }
+
+    data class Properties(
+        val nonFlammableBlockFireChance: Double,
+        val flammableBlockFireChance: Double,
+        val fireTicks: Int,
+        val rocketThrust: Double
+    )
+
+    private inner class FirePellet(
+        private val shooter: LivingEntity,
+        private val world: World,
+        private var position: Vec3d,
+        private val velocity: Vec3d,
+        private val maxAge: Int
+    ) {
+        private var age = 0
+
+        fun tick(attackedEntities: MutableSet<Entity>): Boolean {
+            val newPosition = position + velocity
+            val blockHit = world.raycast(
+                RaycastContext(
+                    position,
+                    newPosition,
+                    RaycastContext.ShapeType.OUTLINE,
+                    RaycastContext.FluidHandling.ANY,
+                    ShapeContext.absent()
+                )
+            )
+            val entityHit = ProjectileUtil.raycast(
+                shooter,
+                position,
+                newPosition,
+                Box(position, newPosition),
+                { true },
+                velocity.lengthSquared()
+            )
+
+            val blockDistance = blockHit.pos.squaredDistanceTo(position)
+            val entityDistance = entityHit?.pos?.squaredDistanceTo(position)
+            if (entityHit != null && entityDistance!! < blockDistance) {
+                tryBurnEntity(entityHit.entity, attackedEntities)
+            } else if (blockHit.type == HitResult.Type.BLOCK) {
+                tryCauseFire(blockHit)
+                return false
+            }
+
+            position = newPosition
+            return ++age < maxAge
+        }
+
+        private fun tryBurnEntity(target: Entity, ignoredEntities: MutableSet<Entity>) {
+            if (target in ignoredEntities) return
+
+            if (target.isOnFire) {
+                // Technically inFire, but use onFire, because it has a more fitting death message
+                target.damage(target.damageSources.onFire(), properties.fireTicks.toFloat())
+            }
+            target.fireTicks = target.fireTicks.coerceAtLeast(0) + properties.fireTicks + 1
+            (target as? LivingEntity)?.attacker = shooter
+            ignoredEntities += target
+        }
+
+        private fun tryCauseFire(blockHit: BlockHitResult) {
+            val firePos = blockHit.blockPos.offset(blockHit.side)
+            val blockToLight = world.getBlockState(blockHit.blockPos)
+            if (CampfireBlock.canBeLit(blockToLight) ||
+                CandleBlock.canBeLit(blockToLight) ||
+                CandleCakeBlock.canBeLit(blockToLight)
+            ) {
+                world.setBlockState(blockHit.blockPos, blockToLight.with(LIT, true), Block.NOTIFY_ALL_AND_REDRAW)
+                world.emitGameEvent(shooter, GameEvent.BLOCK_CHANGE, firePos)
+                return
+            }
+
+            if (!world.canSetBlock(firePos)) return
+            if (!AbstractFireBlock.canPlaceAt(world, firePos, shooter.horizontalFacing)) return
+
+            var fireCauseChance =
+                if (world.getBlockState(blockHit.blockPos).isBurnable) properties.flammableBlockFireChance
+                else properties.nonFlammableBlockFireChance
+            fireCauseChance /= FLAMETHROWER_CONE_RAYS_TOTAL
+            if (Math.random() >= fireCauseChance) return
+
+            world.setBlockState(firePos, AbstractFireBlock.getState(world, firePos), Block.NOTIFY_ALL_AND_REDRAW)
+            world.emitGameEvent(shooter, GameEvent.BLOCK_PLACE, firePos)
+        }
+    }
+
+    private companion object : TickEvent.Server {
+        private const val FLAME_SPEED = 1.0
+        private const val FLAME_MAX_AGE = 16
+        private const val FLAME_MAX_DISTANCE = FLAME_SPEED * FLAME_MAX_AGE
+
+        private const val FLAMETHROWER_CONE_END_WIDTH = 0.25 * FLAME_MAX_DISTANCE
+        private const val FLAMETHROWER_CONE_END_HEIGHT = 0.25 * FLAME_MAX_DISTANCE
+        private const val FLAMETHROWER_CONE_RAYS = 16
+        private const val FLAMETHROWER_CONE_RAYS_TOTAL = FLAMETHROWER_CONE_RAYS * FLAMETHROWER_CONE_RAYS
+
+        private const val ROCKET_MODE_KEY = "RocketMode"
+
+        private val flameParticleCount: Int
+            @Environment(EnvType.CLIENT)
+            get() = when (MinecraftClient.getInstance().options.graphicsMode.value!!) {
+                GraphicsMode.FAST -> 4 * 4
+                GraphicsMode.FANCY -> 8 * 8
+                GraphicsMode.FABULOUS -> 16 * 16
+            }
+        private val firePellets = mutableListOf<FirePellet>()
+
+        init {
+            TickEvent.SERVER_PRE.register(this)
+        }
+
+        private fun shootFire(firePellet: FirePellet) {
+            firePellets += firePellet
+        }
+
+        override fun tick(server: MinecraftServer) {
+            val damagedEntities = mutableSetOf<Entity>()
+            val iterator = firePellets.iterator()
+            while (iterator.hasNext()) {
+                val pellet = iterator.next()
+                if (!pellet.tick(damagedEntities)) {
+                    iterator.remove()
+                }
+            }
+        }
+    }
+}

--- a/StaffMod/src/main/kotlin/opekope2/avm_staff/internal/staff_item_handler/FurnaceHandler.kt
+++ b/StaffMod/src/main/kotlin/opekope2/avm_staff/internal/staff_item_handler/FurnaceHandler.kt
@@ -85,6 +85,8 @@ class FurnaceHandler<TRecipe : AbstractCookingRecipe>(
     }
 
     override fun usageTick(staffStack: ItemStack, world: World, user: LivingEntity, remainingUseTicks: Int) {
+        if (!user.canUseStaff) return
+
         val itemToSmelt = findItemToSmelt(user, world)
 
         if (world.isClient) {

--- a/StaffMod/src/main/kotlin/opekope2/avm_staff/internal/staff_item_handler/MagmaBlockHandler.kt
+++ b/StaffMod/src/main/kotlin/opekope2/avm_staff/internal/staff_item_handler/MagmaBlockHandler.kt
@@ -76,6 +76,8 @@ class MagmaBlockHandler : StaffItemHandler() {
     }
 
     private fun shootFireball(world: World, user: LivingEntity) {
+        if (!user.canUseStaff) return
+
         world.syncWorldEvent(user as? PlayerEntity, WorldEvents.BLAZE_SHOOTS, user.blockPos, 0)
 
         if (world.isClient) return

--- a/StaffMod/src/main/kotlin/opekope2/avm_staff/internal/staff_item_handler/SnowBlockHandler.kt
+++ b/StaffMod/src/main/kotlin/opekope2/avm_staff/internal/staff_item_handler/SnowBlockHandler.kt
@@ -28,10 +28,7 @@ import net.minecraft.util.Hand
 import net.minecraft.util.TypedActionResult
 import net.minecraft.world.World
 import opekope2.avm_staff.api.item.StaffItemHandler
-import opekope2.avm_staff.util.approximateStaffTipPosition
-import opekope2.avm_staff.util.component1
-import opekope2.avm_staff.util.component2
-import opekope2.avm_staff.util.component3
+import opekope2.avm_staff.util.*
 
 class SnowBlockHandler : StaffItemHandler() {
     override val maxUseTime = 72000
@@ -56,6 +53,8 @@ class SnowBlockHandler : StaffItemHandler() {
     }
 
     private fun throwSnowball(world: World, user: LivingEntity) {
+        if (!user.canUseStaff) return
+
         world.playSound(
             user,
             user.blockPos,

--- a/StaffMod/src/main/kotlin/opekope2/avm_staff/internal/staff_item_handler/VanillaStaffItemHandlers.kt
+++ b/StaffMod/src/main/kotlin/opekope2/avm_staff/internal/staff_item_handler/VanillaStaffItemHandlers.kt
@@ -25,6 +25,7 @@ import net.minecraft.item.Items
 import net.minecraft.recipe.RecipeType
 import net.minecraft.registry.Registries
 import net.minecraft.sound.SoundEvents
+import opekope2.avm_staff.IStaffMod
 import opekope2.avm_staff.api.item.StaffItemHandler
 import opekope2.avm_staff.api.item.model.IStaffItemUnbakedModel
 import opekope2.avm_staff.api.item.model.UnbakedBlockStateModelSupplier
@@ -50,6 +51,21 @@ fun registerVanillaStaffItemHandlers() {
     Items.BELL.registerHandler(BellBlockHandler(), BellBlockHandler.modelSupplierFactory)
 
     Items.BONE_BLOCK.registerHandler(BoneBlockHandler(), BONE_BLOCK)
+
+    Items.CAMPFIRE.registerHandler(
+        CampfireHandler(
+            IStaffMod::flamethrowerParticleType,
+            CampfireHandler.Properties(1 / 20.0, 5 / 20.0, 1, 0.1)
+        ),
+        CAMPFIRE
+    )
+    Items.SOUL_CAMPFIRE.registerHandler(
+        CampfireHandler(
+            IStaffMod::soulFlamethrowerParticleType,
+            CampfireHandler.Properties(2 / 20.0, 10 / 20.0, 2, 0.12)
+        ),
+        SOUL_CAMPFIRE
+    )
 
     Items.FURNACE.registerHandler(
         FurnaceHandler(RecipeType.SMELTING, SoundEvents.BLOCK_FURNACE_FIRE_CRACKLE),

--- a/StaffMod/src/main/kotlin/opekope2/avm_staff/util/StaffUtil.kt
+++ b/StaffMod/src/main/kotlin/opekope2/avm_staff/util/StaffUtil.kt
@@ -24,7 +24,9 @@ import net.minecraft.entity.Entity
 import net.minecraft.item.ItemStack
 import net.minecraft.nbt.NbtCompound
 import net.minecraft.registry.Registries
+import net.minecraft.util.hit.HitResult
 import net.minecraft.util.math.Vec3d
+import net.minecraft.world.RaycastContext
 import opekope2.avm_staff.api.item.StaffItemHandler
 
 /**
@@ -103,3 +105,17 @@ val Entity.approximateStaffTipPosition: Vec3d
  */
 val Entity.approximateStaffItemPosition: Vec3d
     get() = eyePos + rotationVector * (STAFF_MODEL_ITEM_POSITION_CENTER * STAFF_MODEL_SCALE)
+
+/**
+ * Checks if the user has sufficient space in front to use the staff.
+ */
+val Entity.canUseStaff: Boolean
+    get() = world.raycast(
+        RaycastContext(
+            eyePos,
+            eyePos + rotationVector * STAFF_MODEL_LENGTH,
+            RaycastContext.ShapeType.OUTLINE,
+            RaycastContext.FluidHandling.NONE,
+            this
+        )
+    ).type == HitResult.Type.MISS

--- a/StaffMod/src/main/resources/assets/avm_staff/particles/flame.json
+++ b/StaffMod/src/main/resources/assets/avm_staff/particles/flame.json
@@ -1,0 +1,5 @@
+{
+  "textures": [
+    "minecraft:flame"
+  ]
+}

--- a/StaffMod/src/main/resources/assets/avm_staff/particles/soul_fire_flame.json
+++ b/StaffMod/src/main/resources/assets/avm_staff/particles/soul_fire_flame.json
@@ -1,0 +1,5 @@
+{
+  "textures": [
+    "minecraft:soul_fire_flame"
+  ]
+}

--- a/StaffMod/src/main/resources/avm_staff.mixins.json
+++ b/StaffMod/src/main/resources/avm_staff.mixins.json
@@ -14,6 +14,7 @@
   ],
   "mixins": [
     "IAbstractFurnaceBlockEntityMixin",
+    "IEntityMixin",
     "LivingEntityMixin",
     "TntEntityMixin"
   ]

--- a/StaffMod/src/main/resources/avm_staff.mixins.json
+++ b/StaffMod/src/main/resources/avm_staff.mixins.json
@@ -9,6 +9,7 @@
   "client": [
     "BipedEntityModelMixin",
     "IMinecraftClientMixin",
+    "IParticleMixin",
     "MinecraftClientMixin"
   ],
   "mixins": [

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ mixin_extras_version=0.3.5
 java_version=17
 ##########################################################################
 # Mod Properties
-mod_version=0.12.0-beta
+mod_version=0.13.0-beta
 maven_group=opekope2.avm_staff
 archives_name=staff-mod
 ##########################################################################


### PR DESCRIPTION
* Fix staff model's missing model loader - only used, if a staff contains an item, which has no item handler registered. Only possible if the item's NBT is edited or by using other mods (latter is unlikely)
* Change furnaces, magma block, and snow block staff to check for clearance - this is to prevent shooting through walls
* Add campfire and soul campfire staffs